### PR TITLE
migrate from renovate to dependabot

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -1,0 +1,31 @@
+name: Update Flake Inputs
+on:
+  schedule:
+    - cron: "0 2 * * 0"
+  workflow_dispatch:
+jobs:
+  update-flake-inputs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v31
+      - name: Update flake inputs
+        uses: mic92/update-flake-inputs@main
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          auto-merge: true
+          # Optional: exclude specific files or inputs
+          # exclude-patterns: 'tests/**/flake.nix,examples/**/flake.nix#home-manager'

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":dependencyDashboard"],
-  "nix": {
-    "enabled": true
-  },
-  "lockFileMaintenance": { "enabled": true }
-}


### PR DESCRIPTION

- Remove renovate.json
- Add auto-merge workflow for dependency updates
- Add update-flake-inputs workflow (requires APP_ID and APP_PRIVATE_KEY secrets)


