### PR TITLE
Binary builds for hosts without NixOS or go toolchains

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.23'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,7 @@
 # This workflow will build a golang project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
-name: Go
+name: Go build and test
 
 on:
   push:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go build and test
 
 on:
   push:
-    branches: [ "joseph-long-go-ci" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "joseph-long-go-ci" ]
+    branches: [ "main" ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "joseph-long-go-ci" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "joseph-long-go-ci" ]
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Cross-compile and release binaries
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: GoReleaser Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+        id: go
+
+      - name: run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,17 +48,16 @@ builds:
       - windows
     goarch:
       - amd64
-      - arm64
     hooks:
       post:
         - upx -9 "{{ .Path }}"
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.xz
+    formats: tar.xz
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
     wrap_in_directory: true
     files:
       - LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,76 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+    - go test
+
+builds:
+  - id: ssh-to-age
+    binary: ssh-to-age
+    dir: ./cmd/ssh-to-age
+    ldflags:
+      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - freebsd
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - ppc64le
+    goarm:
+      - "7"
+    ignore:
+      - goos: freebsd
+        goarch: arm64
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: ppc64le
+      - goos: darwin
+        goarch: arm
+      - goos: darwin
+        goarch: ppc64le
+
+  - id: ssh-to-age-win
+    binary: ssh-to-age
+    dir: ./cmd/ssh-to-age
+    ldflags:
+      - -extldflags "-static" -s -w -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X main.Version={{.Version}} -X main.Revision={{.ShortCommit}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        - upx -9 "{{ .Path }}"
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.xz
+    format_overrides:
+      - goos: windows
+        format: zip
+    wrap_in_directory: true
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}--checksums.txt"
+release:
+  draft: true
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ $ nix-shell -p 'import (fetchTarball "https://github.com/Mic92/ssh-to-age/archiv
 ```console
 $ go install github.com/Mic92/ssh-to-age/cmd/ssh-to-age@latest
 ```
+
+## Use a released binary
+
+Tagged releases are built with [GoReleaser](https://goreleaser.com/) and a GitHub Actions workflow following this [post](https://gitgist.com/posts/goreleaser-and-github-actions/).
+
+These are offered on a best-effort basis. (Aside from automated unit tests and the occasional spot check, these are not tested or supported.)


### PR DESCRIPTION
Thanks for writing and sharing this tool! I have added workflows that build and attach binaries to (draft) releases on tag pushes. 

I am administering a mix of NixOS and non-NixOS machines from a macOS laptop, so this was just a nice convenience for me. The [blog post](https://gitgist.com/posts/goreleaser-and-github-actions/) I followed for implementing has a big matrix of OS/arch support, so I just let it build everything that worked (which is everything but Windows ARM, because UPX doesn't support it).

If this is useful, I'd be happy to see it upstreamed 😃 