### PR TITLE
Update README with `systemd-ask-password` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ $ read -s SSH_TO_AGE_PASSPHRASE; export SSH_TO_AGE_PASSPHRASE
 $ ssh-to-age -private-key -i $HOME/.ssh/id_ed25519 -o key.txt
 ```
 
+Alternatively, use `systemd-ask-password` and only add the environmental variable for a single command:
+
+```console
+$ SSH_TO_AGE_PASSPHRASE=$(systemd-ask-password) ssh-to-age -private-key -i $HOME/.ssh/id_ed25519 -o key.txt
+```
+
 - Exports the public key:
 
 ```console


### PR DESCRIPTION
Added alternative method for SSH passphrase input using `systemd-ask-password`.
This feels safer to me than leaving the passphrase in the environment for the rest of the shell session.