### PR TITLE
feat: add -stdinpass to enable reading private key passphrase from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ssh-to-age
+
 Convert SSH Ed25519 keys to [age](https://github.com/FiloSottile/age) keys.
 This is useful for usage in [sops-nix](https://github.com/Mic92/sops-nix) and
 [sops](https://github.com/mozilla/sops)
@@ -13,18 +14,14 @@ $ cat key.txt
  AGE-SECRET-KEY-1K3VN4N03PTHJWSJSCCMQCN33RY5FSKQPJ4KRRTG3JMQUYE0TUSEQEDH6V8
 ```
 
-If you private key is encrypted, you can export the password in `SSH_TO_AGE_PASSPHRASE`
-
-``` console
-$ read -s SSH_TO_AGE_PASSPHRASE; export SSH_TO_AGE_PASSPHRASE
-$ ssh-to-age -private-key -i $HOME/.ssh/id_ed25519 -o key.txt
-```
-
-Alternatively, use `systemd-ask-password` and only add the environmental variable for a single command:
+If your private key is encrypted, pipe the passphrase via `-stdinpass`:
 
 ```console
-$ SSH_TO_AGE_PASSPHRASE=$(systemd-ask-password) ssh-to-age -private-key -i $HOME/.ssh/id_ed25519 -o key.txt
+$ systemd-ask-password | ssh-to-age -private-key -stdinpass -i $HOME/.ssh/id_ed25519 -o key.txt
+$ security find-generic-password -w -s 'SSH Key Passphrase' | ssh-to-age -private-key -stdinpass -i $HOME/.ssh/id_ed25519 -o key.txt
 ```
+
+Alternatively, pass it via `SSH_TO_AGE_PASSPHRASE` environment variable.
 
 - Exports the public key:
 

--- a/cmd/ssh-to-age/main.go
+++ b/cmd/ssh-to-age/main.go
@@ -17,6 +17,7 @@ var version = "dev"
 type options struct {
 	out, in     string
 	privateKey  bool
+	stdinPass   bool
 	showVersion bool
 }
 
@@ -26,6 +27,7 @@ func parseFlags(args []string) options {
 	f.BoolVar(&opts.privateKey, "private-key", false, "convert private key instead of public key")
 	f.StringVar(&opts.in, "i", "-", "Input path. Reads by default from standard input")
 	f.StringVar(&opts.out, "o", "-", "Output path. Prints by default to standard output")
+	f.BoolVar(&opts.stdinPass, "stdinpass", false, "read private key passphrase from standard input")
 	f.BoolVar(&opts.showVersion, "version", false, "show version and exit")
 	if err := f.Parse(args[1:]); err != nil {
 		// should never happen since flag.ExitOnError
@@ -80,6 +82,16 @@ func convertKeys(args []string) error {
 		)
 
 		keyPassphrase := os.Getenv("SSH_TO_AGE_PASSPHRASE")
+		if opts.stdinPass {
+			if opts.in == "-" {
+				return fmt.Errorf("cannot read both private key and passphrase from stdin")
+			}
+			passphrase, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("error reading passphrase from stdin: %w", err)
+			}
+			keyPassphrase = strings.TrimRight(string(passphrase), "\r\n")
+		}
 
 		key, _, err = sshage.SSHPrivateKeyToAge(sshKey, []byte(keyPassphrase))
 		if err != nil {

--- a/cmd/ssh-to-age/main_test.go
+++ b/cmd/ssh-to-age/main_test.go
@@ -115,6 +115,60 @@ func TestPrivateKeyWithPassphrase(t *testing.T) {
 	ok(t, err)
 }
 
+func TestPrivateKeyWithStdinPassphrase(t *testing.T) {
+	tempdir := TempDir(t)
+	defer os.RemoveAll(tempdir)
+	out := path.Join(tempdir, "out")
+
+	stdin, err := os.CreateTemp(tempdir, "stdin")
+	ok(t, err)
+	defer stdin.Close()
+
+	_, err = stdin.WriteString("test\n")
+	ok(t, err)
+
+	_, err = stdin.Seek(0, 0)
+	ok(t, err)
+
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	err = convertKeys([]string{"ssh-to-age", "-private-key", "-stdinpass", "-i", Asset("id_ed25519_passphrase"), "-o", out})
+	ok(t, err)
+
+	rawPrivateKey, err := ioutil.ReadFile(out)
+	privateKey := strings.TrimSuffix(string(rawPrivateKey), "\n")
+	ok(t, err)
+
+	fmt.Printf("private key: %s\n", privateKey)
+	_, err = age.ParseX25519Identity(privateKey)
+	ok(t, err)
+}
+
+func TestStdinPassphraseRequiresFileInput(t *testing.T) {
+	stdin, err := os.CreateTemp(os.TempDir(), "stdin")
+	ok(t, err)
+	defer os.Remove(stdin.Name())
+	defer stdin.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
+	err = convertKeys([]string{"ssh-to-age", "-private-key", "-stdinpass"})
+	if err == nil {
+		t.Fatal("expected error when reading both private key and passphrase from stdin")
+	}
+	if got, want := err.Error(), "cannot read both private key and passphrase from stdin"; got != want {
+		t.Fatalf("unexpected error: got %q, want %q", got, want)
+	}
+}
+
 func TestVersionFlag(t *testing.T) {
 	tempdir := TempDir(t)
 	defer os.RemoveAll(tempdir)


### PR DESCRIPTION
### Changelog

- add -stdinpass for reading private key passphrases from stdin
- keep former SSH_TO_AGE_PASSPHRASE as an alternative
- document usage
- add tests
