### PR TITLE
flake: drop flake-parts dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777678872,
-        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777578337,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,48 +3,42 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:/hercules-ci/flake-parts";
-    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } (
-      { lib, ... }:
-      {
-        systems = [
-          "aarch64-linux"
-          "x86_64-linux"
-          "riscv64-linux"
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "riscv64-linux"
 
-          "x86_64-darwin"
-          "aarch64-darwin"
-        ];
-        perSystem =
-          {
-            config,
-            self',
-            pkgs,
-            ...
-          }:
-          {
-            packages = {
-              ssh-to-age = (pkgs.callPackage ./default.nix { });
-              default = config.packages.ssh-to-age;
-            };
-            checks =
-              let
-                packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
-                devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") self'.devShells;
-              in
-              {
-                cross-build = pkgs.callPackage ./cross-build.nix { 
-                  ssh-to-age = self'.packages.ssh-to-age;
-                };
-              }
-              // packages
-              // devShells;
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = eachSystem (pkgs: rec {
+        ssh-to-age = pkgs.callPackage ./default.nix { };
+        default = ssh-to-age;
+      });
+
+      checks = eachSystem (
+        pkgs:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+          packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self.packages.${system};
+          devShells = lib.mapAttrs' (n: lib.nameValuePair "devShell-${n}") (self.devShells.${system} or { });
+        in
+        {
+          cross-build = pkgs.callPackage ./cross-build.nix {
+            inherit (self.packages.${system}) ssh-to-age;
           };
-      }
-    );
+        }
+        // packages
+        // devShells
+      );
+    };
 }


### PR DESCRIPTION
This flake only used flake-parts for a trivial perSystem mapping.
Replace it with nixpkgs.lib.genAttrs to remove an unnecessary input
and reduce lock file churn.
