### PR TITLE
flake: drop x86_64-darwin, bump version to 1.3.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {}, vendorHash ? "sha256-n/IzOYsxbDiHk0U77Fs0lKaDJQ7n6my7E33mwwwXOT4=" }:
 let
   fs = pkgs.lib.fileset;
-  version = "1.2.0";
+  version = "1.3.0";
 in
 pkgs.buildGoModule {
   pname = "ssh-to-age";

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
         "x86_64-linux"
         "riscv64-linux"
 
-        "x86_64-darwin"
         "aarch64-darwin"
       ];
       eachSystem = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});


### PR DESCRIPTION
Nixpkgs 26.11 dropped support for x86_64-darwin, which breaks evaluation with newer nixpkgs inputs (blocking #232). Also syncs the package version with the v1.3.0 release.

Fixes #215.